### PR TITLE
Support ruby 3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,13 +2,13 @@ PATH
   remote: .
   specs:
     tabularize (0.2.10)
-      unicode-display_width (>= 1.3.0)
+      unicode-display_width (>= 2.0.0)
 
 GEM
   remote: http://rubygems.org/
   specs:
     minitest (5.10.3)
-    unicode-display_width (1.3.0)
+    unicode-display_width (2.0.0)
 
 PLATFORMS
   java

--- a/lib/tabularize.rb
+++ b/lib/tabularize.rb
@@ -6,6 +6,7 @@
 require 'tabularize/version'
 require 'stringio'
 require 'unicode/display_width'
+require 'unicode/display_width/string_ext'
 require 'English'
 
 class Tabularize

--- a/tabularize.gemspec
+++ b/tabularize.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |s|
 
   # specify any dependencies here; for example:
   s.add_development_dependency 'minitest'
-  s.add_runtime_dependency 'unicode-display_width', '>= 1.3.0'
+  s.add_runtime_dependency 'unicode-display_width', '>= 2.0.0'
 end


### PR DESCRIPTION
- update unicode-display_width deps
- explicitly require string_ext

test result with ruby 3.0.1p64 was: 

```
...
Run options: --seed 31153

# Running:

..>
>
>
>
>
>
>
>
>
>
>
>
>
>
>
>
>
>
>
>
>
>
>
>
>
>
+------->
| 12345 >
| 12345 >
| 12345 >
| 12345 >
| 12345 >
| 12345 >
| 12345 >
| 12345 >
| 12345 >
| 12345 >
| 12345 >
+------->
+-------+-------+-------+-------+-------+------->
| 12345 | 12345 | 12345 | 12345 | 12345 | 12345 >
| 12345 | 12345 | 12345 | 12345 | 12345 | 12345 >
| 12345 | 12345 | 12345 | 12345 | 12345 | 12345 >
| 12345 | 12345 | 12345 | 12345 | 12345 | 12345 >
| 12345 | 12345 | 12345 | 12345 | 12345 | 12345 >
| 12345 | 12345 | 12345 | 12345 | 12345 | 12345 >
| 12345 | 12345 | 12345 | 12345 | 12345 | 12345 >
| 12345 | 12345 | 12345 | 12345 | 12345 | 12345 >
| 12345 | 12345 | 12345 | 12345 | 12345 | 12345 >
| 12345 | 12345 | 12345 | 12345 | 12345 | 12345 >
| 12345 |       |       |       |       |       >
+-------+-------+-------+-------+-------+------->
+-------+-------+-------+-------+-------+-------+-------+-------+------->
| 12345 | 12345 | 12345 | 12345 | 12345 | 12345 | 12345 | 12345 | 12345 >
| 12345 | 12345 | 12345 | 12345 | 12345 | 12345 | 12345 | 12345 | 12345 >
| 12345 | 12345 | 12345 | 12345 | 12345 | 12345 | 12345 | 12345 | 12345 >
| 12345 | 12345 | 12345 | 12345 | 12345 | 12345 | 12345 | 12345 | 12345 >
| 12345 | 12345 | 12345 | 12345 | 12345 | 12345 | 12345 | 12345 | 12345 >
| 12345 | 12345 | 12345 | 12345 | 12345 | 12345 | 12345 | 12345 | 12345 >
| 12345 | 12345 | 12345 | 12345 | 12345 | 12345 | 12345 | 12345 | 12345 >
| 12345 | 12345 | 12345 | 12345 | 12345 | 12345 | 12345 | 12345 | 12345 >
| 12345 | 12345 | 12345 | 12345 | 12345 | 12345 | 12345 | 12345 | 12345 >
| 12345 | 12345 | 12345 | 12345 | 12345 | 12345 | 12345 | 12345 | 12345 >
| 12345 |       |       |       |       |       |       |       |       >
+-------+-------+-------+-------+-------+-------+-------+-------+------->
..........

Finished in 0.083039s, 144.5104 runs/s, 2095.4010 assertions/s.

12 runs, 174 assertions, 0 failures, 0 errors, 0 skips
```